### PR TITLE
Add additional logging to assist with debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "test"
   },
   "dependencies": {
-    "code42day-vis-why": "^1.0.3"
+    "code42day-vis-why": "^1.0.3",
+    "debug": "^2.2.0"
   },
   "devDependencies": {
     "cz-conventional-changelog": "^1.1.6",

--- a/src/lib/routing-table.js
+++ b/src/lib/routing-table.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const debug = require('debug')('five-bells-routing:routing-table')
+
 class RoutingTable {
   constructor () {
     this.destinations = new Map()
@@ -23,7 +25,11 @@ class RoutingTable {
 
   findBestHopForSourceAmount (destination, sourceAmount) {
     const routes = this.destinations.get(destination)
-    if (!routes) return undefined
+    if (!routes) {
+      debug('destination %s is not in known destinations: %s',
+        destination, Array.from(this.destinations.keys()))
+      return undefined
+    }
 
     let bestHop = null
     let bestValue = -1
@@ -42,7 +48,11 @@ class RoutingTable {
 
   findBestHopForDestinationAmount (destination, destinationAmount) {
     const routes = this.destinations.get(destination)
-    if (!routes) return undefined
+    if (!routes) {
+      debug('destination %s is not in known destinations: %s',
+        destination, Array.from(this.destinations.keys()))
+      return undefined
+    }
 
     let bestHop = null
     let bestCost = Infinity

--- a/src/lib/routing-tables.js
+++ b/src/lib/routing-tables.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const debug = require('debug')('five-bells-routing:routing-tables')
+
 const Route = require('./route')
 const RoutingTable = require('./routing-table')
 // A next hop of PAIR distinguishes a local pair A→B from a complex route
@@ -209,13 +211,23 @@ class RoutingTables {
   }
 
   _findBestHopForSourceAmount (source, destination, amount) {
-    if (!this.sources[source]) return
+    debug('searching best hop from %s to %s for %s (by src amount)', source, destination, amount)
+    if (!this.sources[source]) {
+      debug('source %s is not in known sources: %s',
+        source, Object.keys(this.sources))
+      return undefined
+    }
     return this._rewriteLocalHop(
       this.sources[source].findBestHopForSourceAmount(destination, amount))
   }
 
   _findBestHopForDestinationAmount (source, destination, amount) {
-    if (!this.sources[source]) return
+    debug('searching best hop from %s to %s for %s (by dst amount)', source, destination, amount)
+    if (!this.sources[source]) {
+      debug('source %s is not in known sources: %s',
+        source, Object.keys(this.sources))
+      return undefined
+    }
     return this._rewriteLocalHop(
       this.sources[source].findBestHopForDestinationAmount(destination, amount))
   }


### PR DESCRIPTION
Currently, this library will return no route for a variety of reasons. By adding some logging we can make it easier to see which step of the process failed.